### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ maildir-utils (1.4.3-2) UNRELEASED; urgency=medium
   * Use secure URI in Homepage field.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Rely on pre-initialized dpkg-architecture variables.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 15:06:06 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ maildir-utils (1.4.3-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Use secure URI in Homepage field.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 15:06:06 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+maildir-utils (1.4.3-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 15:06:06 +0000
+
 maildir-utils (1.4.3-1) unstable; urgency=medium
 
   * New upstream version 1.4.3
@@ -85,7 +91,7 @@ maildir-utils (1.0-4) unstable; urgency=medium
 
 maildir-utils (1.0-3) unstable; urgency=medium
 
-  * don't request non-existing libguile-2.2-dev on armel 
+  * don't request non-existing libguile-2.2-dev on armel
 
  -- Norbert Preining <preining@debian.org>  Tue, 08 May 2018 13:42:47 +0900
 
@@ -94,7 +100,7 @@ maildir-utils (1.0-2) unstable; urgency=medium
   * fix NEWS entry in mu4e welcome screen (Closes: #882341)
     - install everything into /u/s/d/maildir-utils
     - adjust MU_DOC_DIR to refer to it
-  * reintroduce maildir-utils-extra with mug 
+  * reintroduce maildir-utils-extra with mug
 
  -- Norbert Preining <preining@debian.org>  Wed, 04 Apr 2018 01:58:11 +0900
 
@@ -111,7 +117,7 @@ maildir-utils (1.0-1) unstable; urgency=medium
 
 maildir-utils (0.9.18-2) unstable; urgency=medium
 
-  * drop maildir-utils-extra package, mug/msg2pdf cannot be build with 
+  * drop maildir-utils-extra package, mug/msg2pdf cannot be build with
     webkitgtk4 (Closes: #866645)
   * bump standards version, no changes necessary
 
@@ -253,7 +259,7 @@ maildir-utils (0.9.9-1) unstable; urgency=low
 
 maildir-utils (0.9.8.5-3) unstable; urgency=low
 
-  * restrict mu4e and m-u-e's dependency on maildir-utils to the same 
+  * restrict mu4e and m-u-e's dependency on maildir-utils to the same
     version (and including bin-nmus for mu4e)
 
  -- Norbert Preining <preining@debian.org>  Thu, 23 Aug 2012 09:22:35 +0900
@@ -284,7 +290,7 @@ maildir-utils (0.9.8.4-3) unstable; urgency=high
 
 maildir-utils (0.9.8.4-2) unstable; urgency=low
 
-  * mention GFDL without invariant sections etc for mu4e.texi etc 
+  * mention GFDL without invariant sections etc for mu4e.texi etc
     (Closes: #672596)
   * fix FTBFS due to xapian version check being to strict (Closes: #672707)
 
@@ -334,7 +340,7 @@ maildir-utils (0.9.6.99.1-1) unstable; urgency=low
   * make lintian happy by adding some recommended targets in debian/rules
   * rename maildir-utils-gtk to maildir-utils-extra as we will probably
     include the guile interface and some other things there, soon.
-    Add accordingly replaces and conflicts to debian/control, and 
+    Add accordingly replaces and conflicts to debian/control, and
     adapt debian/rules.
 
  -- Norbert Preining <preining@debian.org>  Tue, 23 Aug 2011 11:03:26 +0900

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 maildir-utils (1.4.3-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Use secure URI in Homepage field.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 29 Apr 2020 15:06:06 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
 Build-Depends: libxapian-dev, debhelper-compat (= 12), zlib1g-dev, libgtk-3-dev, xdg-utils, emacsen-common (>= 2.0.8), guile-2.2-dev, texinfo, pmccabe, libgmime-3.0-dev
 Standards-Version: 4.5.0
-Homepage: http://www.djcbsoftware.nl/code/mu/
+Homepage: https://www.djcbsoftware.nl/code/mu/
 Vcs-Git: https://github.com/norbusan/debian-mu.git
 Vcs-Browser: https://github.com/norbusan/debian-mu
 

--- a/debian/control
+++ b/debian/control
@@ -16,14 +16,14 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, dpkg (>= 1.15.4) | install-info
 Conflicts: mailutils (<< 1:2.99.97-3)
 Replaces: mailutils (<< 1:2.99.97-3)
 Description: Set of utilities to deal with Maildirs (upstream name mu)
- mu is a set of utilities to deal with Maildirs, specifically, 
- indexing and searching. 
+ mu is a set of utilities to deal with Maildirs, specifically,
+ indexing and searching.
   - mu index - recursively scans a collection of email messages, and
     stores information found in a database.
   - mu find - searches for messages based on some search criteria.
   - mu mkmdir - creates a new Maildir.
  .
- mu uses libgmime to parse the message, and Xapian to store the message data. 
+ mu uses libgmime to parse the message, and Xapian to store the message data.
 
 Package: mu4e
 Section: lisp

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ mu4e := $(CURDIR)/debian/mu4e
 
 DOGUILECONFIG=
 BAD_GUILE_ARCHS := ia64 armel
-DEB_HOST_ARCH     ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
+include /usr/share/dpkg/architecture.mk
 ifneq ($(filter $(DEB_HOST_ARCH),$(BAD_GUILE_ARCHS)),)
   DOGUILECONFIG=--disable-guile
 endif

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/djcb/mu/issues
+Bug-Submit: https://github.com/djcb/mu/issues/new
+Repository: https://github.com/djcb/mu.git
+Repository-Browse: https://github.com/djcb/mu


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Rely on pre-initialized dpkg-architecture variables. ([debian-rules-sets-dpkg-architecture-variable](https://lintian.debian.org/tags/debian-rules-sets-dpkg-architecture-variable.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/maildir-utils/2dafe9b1-7f68-462b-aa3d-ad52e9b530dd.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package maildir-utils: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.djcbsoftware.nl/code/mu/-] {+https&#8203;://www.djcbsoftware.nl/code/mu/+}

No differences were encountered between the control files of package \*\*maildir-utils-dbgsym\*\*
### Control files of package mu4e: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.djcbsoftware.nl/code/mu/-] {+https&#8203;://www.djcbsoftware.nl/code/mu/+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/2dafe9b1-7f68-462b-aa3d-ad52e9b530dd/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/2dafe9b1-7f68-462b-aa3d-ad52e9b530dd/diffoscope)).
