### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: mail
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
 Build-Depends: libxapian-dev, debhelper-compat (= 13), zlib1g-dev, libgtk-3-dev, xdg-utils, emacsen-common (>= 2.0.8), guile-3.0-dev, texinfo, pmccabe, libgmime-3.0-dev, libreadline-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Homepage: https://www.djcbsoftware.nl/code/mu/
 Vcs-Git: https://github.com/norbusan/debian-mu.git
 Vcs-Browser: https://github.com/norbusan/debian-mu

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Vcs-Git: https://github.com/norbusan/debian-mu.git
 Vcs-Browser: https://github.com/norbusan/debian-mu
 
 Package: maildir-utils
-Section: mail
 Priority: optional
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, dpkg (>= 1.15.4) | install-info
@@ -27,7 +26,6 @@ Description: Set of utilities to deal with Maildirs (upstream name mu)
 
 Package: mu4e
 Section: lisp
-Priority: optional
 Architecture: all
 Replaces: maildir-utils (<< 0.9.8.4)
 Conflicts: maildir-utils (<< 0.9.8.4)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: maildir-utils
 Section: mail
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
-Build-Depends: libxapian-dev, debhelper-compat (= 12), zlib1g-dev, libgtk-3-dev, xdg-utils, emacsen-common (>= 2.0.8), guile-3.0-dev, texinfo, pmccabe, libgmime-3.0-dev, libreadline-dev
+Build-Depends: libxapian-dev, debhelper-compat (= 13), zlib1g-dev, libgtk-3-dev, xdg-utils, emacsen-common (>= 2.0.8), guile-3.0-dev, texinfo, pmccabe, libgmime-3.0-dev, libreadline-dev
 Standards-Version: 4.5.0
 Homepage: https://www.djcbsoftware.nl/code/mu/
 Vcs-Git: https://github.com/norbusan/debian-mu.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Remove Section on maildir-utils, Priority on mu4e that duplicate source. ([binary-control-field-duplicates-source](https://lintian.debian.org/tags/binary-control-field-duplicates-source))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/maildir-utils/eca9dfa2-4aaa-4c95-95db-dc2cd404fabf.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/eca9dfa2-4aaa-4c95-95db-dc2cd404fabf/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/eca9dfa2-4aaa-4c95-95db-dc2cd404fabf/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/eca9dfa2-4aaa-4c95-95db-dc2cd404fabf/diffoscope)).
