### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: maildir-utils
 Section: mail
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
-Build-Depends: libxapian-dev, debhelper-compat (= 12), zlib1g-dev, libgtk-3-dev, xdg-utils, emacsen-common (>= 2.0.8), guile-3.0-dev, texinfo, pmccabe, libgmime-3.0-dev, libreadline-dev
+Build-Depends: libxapian-dev, debhelper-compat (= 12), zlib1g-dev, libgtk-3-dev, xdg-utils, emacsen-common, guile-3.0-dev, texinfo, pmccabe, libgmime-3.0-dev, libreadline-dev
 Standards-Version: 4.5.0
 Homepage: https://www.djcbsoftware.nl/code/mu/
 Vcs-Git: https://github.com/norbusan/debian-mu.git
@@ -12,9 +12,7 @@ Package: maildir-utils
 Section: mail
 Priority: optional
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, dpkg (>= 1.15.4) | install-info
-Conflicts: mailutils (<< 1:2.99.97-3)
-Replaces: mailutils (<< 1:2.99.97-3)
+Depends: ${shlibs:Depends}, ${misc:Depends}, dpkg | install-info
 Description: Set of utilities to deal with Maildirs (upstream name mu)
  mu is a set of utilities to deal with Maildirs, specifically,
  indexing and searching.
@@ -29,9 +27,7 @@ Package: mu4e
 Section: lisp
 Priority: optional
 Architecture: all
-Replaces: maildir-utils (<< 0.9.8.4)
-Conflicts: maildir-utils (<< 0.9.8.4)
-Depends: ${misc:Depends}, maildir-utils (>= ${source:Version}), maildir-utils (<< ${source:Version}.1~), emacsen-common (>= 2.0.8), dpkg (>= 1.15.4) | install-info
+Depends: ${misc:Depends}, maildir-utils (>= ${source:Version}), maildir-utils (<< ${source:Version}.1~), emacsen-common, dpkg | install-info
 Description: e-mail client for Emacs based on mu (maildir-utils)
  mu4e (mu-for-emacs) is an e-mail client for GNU-Emacs version 23 and
  later, built on top of the mu e-mail search engine. mu4e is optimized


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/maildir-utils/af56aeba-ae99-494e-8bbe-e4bd5570ad9e.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package maildir-utils: lines which differ (wdiff format)
* [-Conflicts: mailutils (<< 1:2.99.97-3)-]
* Depends: guile-3.0-libs, libc6 (>= 2.30), libgcc-s1 (>= 3.0), libglib2.0-0 (>= 2.55.2), libgmime-3.0-0 (>= 3.0.0), libreadline8 (>= 6.0), libstdc++6 (>= 9), libxapian30 (>= 1.4.17~), dpkg [-(>= 1.15.4)-] | install-info
* [-Replaces: mailutils (<< 1:2.99.97-3)-]

No differences were encountered between the control files of package \*\*maildir-utils-dbgsym\*\*
### Control files of package mu4e: lines which differ (wdiff format)
* [-Conflicts: maildir-utils (<< 0.9.8.4)-]
* Depends: maildir-utils (>=  maildir-utils (<< [-1.6.5-1~jan+control1.1~), emacsen-common (>= 2.0.8),-] {+1.6.5-1~cme+obs1.1~), emacsen-common,+} dpkg [-(>= 1.15.4)-] | install-info
* [-Replaces: maildir-utils (<< 0.9.8.4)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/af56aeba-ae99-494e-8bbe-e4bd5570ad9e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/af56aeba-ae99-494e-8bbe-e4bd5570ad9e/diffoscope)).
