### PR TITLE
Remove Priority on maildir-utils that duplicates source

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Vcs-Git: https://github.com/norbusan/debian-mu.git
 Vcs-Browser: https://github.com/norbusan/debian-mu
 
 Package: maildir-utils
-Priority: optional
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, dpkg | install-info
 Description: Set of utilities to deal with Maildirs (upstream name mu)


### PR DESCRIPTION

Remove Priority on maildir-utils that duplicates source. ([binary-control-field-duplicates-source](https://lintian.debian.org/tags/binary-control-field-duplicates-source))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/maildir-utils/44cda65e-796d-4ccd-9fea-6d6a9d6d6d8e.
